### PR TITLE
Test the migration with TiDB Serverless branching

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,26 @@
+name: migrate-test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: tidbcloud/wait-for-tidbcloud-branch@v0
+        id: wait-for-branch
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          public-key: ${{ secrets.TIDB_CLOUD_PUBLIC_KEY }}
+          private-key: ${{ secrets.TIDB_CLOUD_PRIVATE_KEY }}
+          timeout-seconds: 600
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: migrate-test
+        run: |
+          TIDB_USER=${{ steps.wait-for-branch.outputs.username }} TIDB_PASSWORD=${{ steps.wait-for-branch.outputs.password }} TIDB_HOST=${{ steps.wait-for-branch.outputs.host }} TIDB_CERT_PATH=/etc/ssl/certs/ca-certificates.crt rake db:migrate

--- a/db/migrate/20230906065509_add_index_to_article.rb
+++ b/db/migrate/20230906065509_add_index_to_article.rb
@@ -1,0 +1,6 @@
+#  bin/rails generate migration add_index_to_article title:uniq
+class AddIndexToArticle < ActiveRecord::Migration[7.0]
+  def change
+    add_index :articles, :title, unique: true
+  end
+end


### PR DESCRIPTION
In order to test the migration, we added a GitHub action to run the migration in the created branch. The branch copies the data from TiDB serverless, ensuring we find any potential errors in the migration.

In this example, we want to add a unique index in the title field for the articles table. (The seed already loads the same title in TiDB Serverless)

1. You can see the migration test fails because of the duplicated title name

![image](https://github.com/shiyuhang0/branching-rails-example/assets/52435083/df4d52d0-ce79-4f9e-84a8-c82d67299fb0)

2. After fixing the data problem, we push an empty commit to trigger the action again, and the migration success. 


branching helps us to test the migration and then we can merge this PR and apply the migration to the production cluster.